### PR TITLE
add ipv6 version proxy

### DIFF
--- a/local/proxy_ipv6.ini
+++ b/local/proxy_ipv6.ini
@@ -1,0 +1,138 @@
+[listen]
+ip = 127.0.0.1
+port = 8087
+username =
+password =
+visible = 0
+debuginfo = 0
+
+[gae]
+enable = 1
+appid = 
+password =
+path = /_gh/
+mode = https
+ipv6 = 0
+sslversion = TLSv1
+window = 7
+cachesock = 1
+headfirst = 1
+keepalive = 0
+obfuscate = 0
+validate = 0
+transport = 0
+options =
+regions =
+
+[iplist]
+google_talk = talk.google.com|talk.l.google.com|talkx.l.google.com
+google_ipv6 = ipv6.google.com|2a00:1450:4013:c00::8d|2404:6800:4008:c01::8d|2a00:1450:4013:c00::8b|2a00:1450:4013:c00::2f|2404:6800:4004:802::1003|2404:6800:4004:802::100a|2a00:1450:4013:c00::84|2607:f8b0:4002:c03::8d|2607:f8b0:4002:c04::84|2607:f8b0:4002:c04::52|2404:6800:4008:c01::52
+
+
+[profile]
+.c.docs.google.com = withgae
+.c.pack.google.com = withgae
+.c.bigcache.googleapis.com = withgae
+dl-ssl.google.com = withgae
+dl.google.com = google_ipv6
+play.google.com = withgae
+wenda.google.com.hk = withgae
+clients.google.com = withgae,noforcehttps
+.clients.google.com = withgae,noforcehttps
+clients1.google.com = withgae,noforcehttps
+translate.google.com = withgae,noforcehttps
+mtalk.google.com = direct
+talk.google.com = google_talk
+talk.l.google.com = google_talk
+talkx.l.google.com = google_talk
+.google.cn = google_ipv6
+.appspot.com = google_ipv6,crlf
+.google.com = google_ipv6,forcehttps,fakehttps
+.google.com.hk = google_ipv6,forcehttps,fakehttps
+.commondatastorage.googleapis.com = withgae
+.googleapis.com = google_ipv6,forcehttps,fakehttps
+.googleusercontent.com = google_ipv6,forcehttps,fakehttps
+.googletagservices.com = google_ipv6,forcehttps,fakehttps
+.googletagmanager.com = google_ipv6,forcehttps,fakehttps
+.google-analytics.com = google_ipv6,forcehttps,fakehttps
+.gstatic.com = google_ipv6,forcehttps,fakehttps
+.ggpht.com = google_ipv6,forcehttps,fakehttps
+.googlegroups.com = google_ipv6,forcehttps,fakehttps
+.googlecode.com = google_ipv6,forcehttps,fakehttps
+.youtube.com = forcehttps,fakehttps
+.android.com = google_ipv6,noforcehttps,fakehttps
+tools.android.com = withgae
+www.dropbox.com = withgae
+.dropbox.com:443 = direct
+.box.com:443 = direct
+.copy.com:443 = direct
+https?://www\.google\.com/(?:imgres|url)\?.*url=([^&]+) = $1
+https?://www\.google\.com\.hk/(?:imgres|url)\?.*url=([^&]+) = $1
+https?://www\.google\.com\.hk/search\?(.+) = https://www.google.com/ncr#$1
+; https?://www\.example\.com/.+\.html = file:///C:/README.txt
+; https?://www\.google\.com(\.[a-z]{2})?/($|(search|url|gen_204)\?|(complete|images)/) = google_ipv6
+; https?://www\.youtube\.com/watch = google_ipv6
+; .c.youtube.com =
+; .youtube.com = google_ipv6
+; .googlevideo.com =
+
+[pac]
+enable = 1
+ip = 0.0.0.0
+port = 8086
+file = proxy.pac
+admode = 1
+adblock = https://easylist-downloads.adblockplus.org/easylistchina.txt
+gfwlist = https://autoproxy-gfwlist.googlecode.com/svn/trunk/gfwlist.txt
+expired = 86400
+
+[php]
+enable = 0
+password = 123456
+crlf = 0
+validate = 0
+keepalive = 0
+listen = 127.0.0.1:8088
+fetchserver = http://.com/
+hosts =
+
+[vps]
+enable = 0
+listen = 127.0.0.1:8088
+fetchserver = https://username:123456@vpsserver.com/
+
+[proxy]
+enable = 0
+autodetect = 1
+host = 10.64.1.63
+port = 8080
+username =
+password =
+
+[autorange]
+hosts = *.c.youtube.com|*.atm.youku.com|*.googlevideo.com|*av.vimeo.com|smile-*.nicovideo.jp|video.*.fbcdn.net|s*.last.fm|x*.last.fm|*.x.xvideos.com|*.edgecastcdn.net|*.d.rncdn3.com|cdn*.public.tube8.com|videos.flv*.redtubefiles.com|cdn*.public.extremetube.phncdn.com|cdn*.video.pornhub.phncdn.com|*.mms.vlog.xuite.net|vs*.thisav.com|archive.rthk.hk|video*.modimovie.com|*.c.docs.google.com
+endswith = .f4v|.flv|.hlv|.m4v|.mp4|.mp3|.ogg|.avi|.dmg|.iso
+noendswith = .xml|.json|.html|.php|.py|.js|.css|.jpg|.jpeg|.png|.gif|.ico|.webp
+threads = 3
+maxsize = 1572864
+waitsize = 524288
+bufsize = 8192
+
+[dns]
+enable = 0
+listen = 127.0.0.1:53
+servers = 2001:470:0:45::2|2620:0:ccc::2|2001:4860:4860::8888|2001:4860:4860::8844|2001:470:20::2|209.244.0.3|209.244.0.4|199.91.73.222|178.79.131.110|8.8.8.8|8.8.4.4|208.67.222.222|208.67.220.220|168.95.1.1|168.95.192.1|223.5.5.5|223.6.6.6|114.114.114.114|114.114.115.115|2001:4860:4860::8888|2001:4860:4860::8844|2001:470:20::2
+blacklist = 0.0.0.0|2.1.1.2|28.13.216.0|4.36.66.178|4.193.80.0|8.7.198.45|8.105.84.0|12.87.133.0|14.102.249.18|16.63.155.0|20.139.56.0|23.89.5.60|24.51.184.0|37.61.54.158|46.20.126.252|46.38.24.209|46.82.174.68|49.2.123.56|54.76.135.1|59.24.3.173|61.54.28.6|64.33.88.161|64.33.99.47|64.66.163.251|65.104.202.252|65.160.219.113|66.45.252.237|66.206.11.194|72.14.205.99|72.14.205.104|74.117.57.138|74.125.31.113|74.125.39.102|74.125.39.113|74.125.127.102|74.125.130.47|74.125.155.102|77.4.7.92|78.16.49.15|89.31.55.106|93.46.8.89|113.11.194.190|118.5.49.6|122.218.101.190|123.50.49.171|123.126.249.238|125.230.148.48|127.0.0.1|127.0.0.2|128.121.126.139|159.106.121.75|169.132.13.103|173.201.216.6|188.5.4.96|189.163.17.5|192.67.198.6|197.4.4.12|202.106.1.2|202.181.7.85|203.98.7.65|203.161.230.171|203.199.57.81|207.12.88.98|208.56.31.43|208.109.138.55|209.36.73.33|209.85.229.138|209.145.54.50|209.220.30.174|210.242.125.20|211.5.133.18|211.8.69.27|211.94.66.147|213.169.251.35|213.186.33.5|216.139.213.144|216.221.188.182|216.234.179.13|221.8.69.27|243.185.187.3|243.185.187.30|243.185.187.39|249.129.46.48|253.157.14.165|255.255.255.255|1.1.1.1|183.207.229.|183.207.232.
+tcpover = .youtube.com|.ytimg.com|.googlevideo.com
+
+[useragent]
+enable = 0
+string = Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3
+
+[fetchmax]
+local =
+server =
+
+[love]
+enable = 1
+tip = \u8bf7\u5173\u6ce8\u5317\u4eac\u5931\u5b66\u513f\u7ae5~~


### PR DESCRIPTION
将此文件名改为proxy.ini作为配置文件后，代理的所有流量将定向为ipv6，当然前提是使用者网络支持ipv6地址。适用于限流量的高校学生。